### PR TITLE
feat: implement basic API

### DIFF
--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,0 +1,248 @@
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+// deno-lint-ignore-file no-explicit-any
+
+export interface XMLHttpRequestEventMap
+  extends XMLHttpRequestEventTargetEventMap {
+  readystatechange: Event;
+}
+
+/** Use XMLHttpRequest (XHR) objects to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing. */
+interface XMLHttpRequest extends XMLHttpRequestEventTarget {
+  onreadystatechange: ((this: XMLHttpRequest, ev: Event) => any) | null;
+  /**
+   * Returns client's state.
+   */
+  readonly readyState: number;
+  /**
+   * Returns the response's body.
+   */
+  readonly response: any;
+  /**
+   * Returns the text response.
+   *
+   * Throws an "InvalidStateError" DOMException if responseType is not the empty string or "text".
+   */
+  readonly responseText: string;
+  /**
+   * Returns the response type.
+   *
+   * Can be set to change the response type. Values are: the empty string (default), "arraybuffer", "blob", "document", "json", and "text".
+   *
+   * When set: setting to "document" is ignored if current global object is not a Window object.
+   *
+   * When set: throws an "InvalidStateError" DOMException if state is loading or done.
+   *
+   * When set: throws an "InvalidAccessError" DOMException if the synchronous flag is set and current global object is a Window object.
+   */
+  responseType: XMLHttpRequestResponseType;
+  readonly responseURL: string;
+  /**
+   * Returns the document response.
+   *
+   * Throws an "InvalidStateError" DOMException if responseType is not the empty string or "document".
+   */
+  readonly responseXML: never;
+  readonly status: number;
+  readonly statusText: string;
+  /**
+   * Can be set to a time in milliseconds. When set to a non-zero value will cause fetching to terminate after the given time has passed. When the time has passed, the request has not yet completed, and the synchronous flag is unset, a timeout event will then be dispatched, or a "TimeoutError" DOMException will be thrown otherwise (for the send() method).
+   *
+   * When set: throws an "InvalidAccessError" DOMException if the synchronous flag is set and current global object is a Window object.
+   */
+  timeout: number;
+  /**
+   * Returns the associated XMLHttpRequestUpload object. It can be used to gather transmission information when data is transferred to a server.
+   */
+  readonly upload: XMLHttpRequestUpload;
+  /**
+   * True when credentials are to be included in a cross-origin request. False when they are to be excluded in a cross-origin request and when cookies are to be ignored in its response. Initially false.
+   *
+   * When set: throws an "InvalidStateError" DOMException if state is not unsent or opened, or if the send() flag is set.
+   */
+  withCredentials: boolean;
+  /**
+   * Cancels any network activity.
+   */
+  abort(): void;
+  getAllResponseHeaders(): string;
+  getResponseHeader(name: string): string | null;
+  /**
+   * Sets the request method, request URL, and synchronous flag.
+   *
+   * Throws a "SyntaxError" DOMException if either method is not a valid HTTP method or url cannot be parsed.
+   *
+   * Throws a "SecurityError" DOMException if method is a case-insensitive match for `CONNECT`, `TRACE`, or `TRACK`.
+   *
+   * Throws an "InvalidAccessError" DOMException if async is false, current global object is a Window object, and the timeout attribute is not zero or the responseType attribute is not the empty string.
+   */
+  open(method: string, url: string): void;
+  open(
+    method: string,
+    url: string,
+    async: boolean,
+    username?: string | null,
+    password?: string | null
+  ): void;
+  /**
+   * Acts as if the `Content-Type` header value for response is mime. (It does not actually change the header though.)
+   *
+   * Throws an "InvalidStateError" DOMException if state is loading or done.
+   */
+  overrideMimeType(mime: string): void;
+  /**
+   * Initiates the request. The body argument provides the request body, if any, and is ignored if the request method is GET or HEAD.
+   *
+   * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.
+   */
+  send(body?: BodyInit | null): void;
+  /**
+   * Combines a header in author request headers.
+   *
+   * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.
+   *
+   * Throws a "SyntaxError" DOMException if name is not a header name or if value is not a header value.
+   */
+  setRequestHeader(name: string, value: string): void;
+  readonly DONE: number;
+  readonly HEADERS_RECEIVED: number;
+  readonly LOADING: number;
+  readonly OPENED: number;
+  readonly UNSENT: number;
+  addEventListener<K extends keyof XMLHttpRequestEventMap>(
+    type: K,
+    listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  removeEventListener<K extends keyof XMLHttpRequestEventMap>(
+    type: K,
+    listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any,
+    options?: boolean | EventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
+
+export var XMLHttpRequest: {
+  prototype: XMLHttpRequest;
+  new (): XMLHttpRequest;
+  readonly DONE: number;
+  readonly HEADERS_RECEIVED: number;
+  readonly LOADING: number;
+  readonly OPENED: number;
+  readonly UNSENT: number;
+};
+
+interface XMLHttpRequestEventTargetEventMap {
+  abort: ProgressEvent<XMLHttpRequestEventTarget>;
+  error: ProgressEvent<XMLHttpRequestEventTarget>;
+  load: ProgressEvent<XMLHttpRequestEventTarget>;
+  loadend: ProgressEvent<XMLHttpRequestEventTarget>;
+  loadstart: ProgressEvent<XMLHttpRequestEventTarget>;
+  progress: ProgressEvent<XMLHttpRequestEventTarget>;
+  timeout: ProgressEvent<XMLHttpRequestEventTarget>;
+}
+
+interface XMLHttpRequestEventTarget extends EventTarget {
+  onabort: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  onload: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  onloadend: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  onloadstart: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  onprogress: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  ontimeout: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null;
+  addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+    type: K,
+    listener: (
+      this: XMLHttpRequestEventTarget,
+      ev: XMLHttpRequestEventTargetEventMap[K]
+    ) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+    type: K,
+    listener: (
+      this: XMLHttpRequestEventTarget,
+      ev: XMLHttpRequestEventTargetEventMap[K]
+    ) => any,
+    options?: boolean | EventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
+
+declare var XMLHttpRequestEventTarget: {
+  prototype: XMLHttpRequestEventTarget;
+  new (): XMLHttpRequestEventTarget;
+};
+
+interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
+  addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+    type: K,
+    listener: (
+      this: XMLHttpRequestUpload,
+      ev: XMLHttpRequestEventTargetEventMap[K]
+    ) => any,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  removeEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(
+    type: K,
+    listener: (
+      this: XMLHttpRequestUpload,
+      ev: XMLHttpRequestEventTargetEventMap[K]
+    ) => any,
+    options?: boolean | EventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
+
+declare var XMLHttpRequestUpload: {
+  prototype: XMLHttpRequestUpload;
+  new (): XMLHttpRequestUpload;
+};
+
+type XMLHttpRequestResponseType =
+  | ""
+  | "arraybuffer"
+  | "blob"
+  | "document"
+  | "json"
+  | "text";

--- a/mod.ts
+++ b/mod.ts
@@ -45,7 +45,7 @@ export class XMLHttpRequest
     readyState: this.UNSENT,
   };
 
-  #setReadyState = (newState: number): void => {
+  #setReadyState(newState: number): void {
     this.#state.readyState = newState;
 
     // this technically shouldn't happen in our code but the spec is pretty
@@ -54,7 +54,7 @@ export class XMLHttpRequest
     if (newState === 0) return;
     // deno-lint-ignore no-explicit-any
     (this as any).onreadystatechange?.();
-  };
+  }
 
   // it's supposed to be here
   onreadystatechange: XMLHttpRequestSpec["onreadystatechange"] = null;

--- a/mod.ts
+++ b/mod.ts
@@ -177,7 +177,6 @@ export class XMLHttpRequest
   send(body?: BodyInit | null): void {
     const controller = new AbortController();
     const draft = this.#state.draft!;
-
     const timeoutId = setTimeout(() => {
       controller.abort();
       // deno-lint-ignore no-explicit-any
@@ -187,7 +186,7 @@ export class XMLHttpRequest
     fetch(draft.url, {
       ...draft,
       body,
-      signal: controller.signal,
+      signal: this.timeout > 0 ? controller.signal : undefined,
     })
       .then((res) => {
         clearTimeout(timeoutId);

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,231 @@
+import * as types from "./lib.d.ts";
+
+type XMLHttpRequestSpec = types.XMLHttpRequest;
+
+interface State {
+  readyState: number;
+  draft?: {
+    method: string;
+    url: URL;
+    headers: Headers;
+  };
+  computed?: {
+    type: types.XMLHttpRequestResponseType;
+    blob: Blob;
+    text: string;
+    buffer: ArrayBuffer;
+    // deno-lint-ignore no-explicit-any
+    json?: any; // we are just gonna lazy-load this
+  };
+  controller?: AbortController;
+  response?: Response;
+}
+
+// TODO: actually allow for `addEventListener` to work
+
+export class XMLHttpRequestEventTarget
+  extends EventTarget
+  // This basically makes it ensure that the implemented methods match the spec
+  // and include the JSDoc from the lib.d.ts.
+  implements
+    Pick<types.XMLHttpRequestEventTarget, keyof XMLHttpRequestEventTarget>
+{
+  onload: XMLHttpRequestSpec["onload"] = null;
+  onerror: XMLHttpRequestSpec["onerror"] = null;
+  onloadstart: XMLHttpRequestSpec["onloadstart"] = null;
+  ontimeout: XMLHttpRequestSpec["ontimeout"] = null;
+}
+
+/** Use XMLHttpRequest (XHR) objects to interact with servers. You can retrieve data from a URL without having to do a full page refresh. This enables a Web page to update just part of a page without disrupting what the user is doing. */
+export class XMLHttpRequest
+  extends XMLHttpRequestEventTarget
+  implements Pick<XMLHttpRequestSpec, keyof XMLHttpRequest>
+{
+  #state: State = {
+    readyState: this.UNSENT,
+  };
+
+  #setReadyState = (newState: number): void => {
+    this.#state.readyState = newState;
+
+    // this technically shouldn't happen in our code but the spec is pretty
+    // explicit
+
+    if (newState === 0) return;
+    // deno-lint-ignore no-explicit-any
+    (this as any).onreadystatechange?.();
+  };
+
+  // it's supposed to be here
+  onreadystatechange: XMLHttpRequestSpec["onreadystatechange"] = null;
+
+  timeout = 0;
+
+  // Technically, these need to be getters to implement the spec. Otherwise, we
+  // get type errors.
+
+  get UNSENT(): number {
+    return 0;
+  }
+
+  get OPENED(): number {
+    return 1;
+  }
+
+  get HEADERS_RECEIVED(): number {
+    return 2;
+  }
+
+  get LOADING(): number {
+    return 3;
+  }
+
+  get DONE(): number {
+    return 4;
+  }
+
+  get readyState(): number {
+    return this.#state.readyState;
+  }
+
+  get response(): XMLHttpRequestSpec["response"] {
+    const computed = this.#state.computed!;
+    switch (this.responseType) {
+      case "arraybuffer":
+        return computed.buffer;
+      case "blob":
+        return computed.blob;
+      case "json":
+        computed.json ??= JSON.parse(computed.text);
+        return computed.json;
+      case "text":
+        return computed.text;
+      default:
+        throw Error("Unimplemented.");
+    }
+  }
+
+  // MDN states that this returns `null` if the response hasn't been received
+  // yet, but Chrome just returns `undefined`. Also, the TypeScript types
+  // state that this property returns `string | null`. We'll just return
+  // null` but non-null assert at the end to match keep the types compatible.
+
+  get responseText(): string {
+    return (this.#state.computed?.text ?? null)!;
+  }
+
+  get responseType(): types.XMLHttpRequestResponseType {
+    return (this.#state.computed?.type ?? "text")!;
+  }
+
+  // Refer to the comment above as the situation is the same. I dunno what the
+  // TypeScript JSDoc is saying about throwing errors as that is definitely
+  // not in the spec.
+
+  // TODO: exclude fragment flag set
+  // ref: https://xhr.spec.whatwg.org/#the-responseurl-attribute
+
+  get responseURL(): string {
+    return (this.#state.response?.url ?? null)!;
+  }
+
+  get responseXML(): XMLHttpRequestSpec["responseXML"] {
+    throw Error("Unimplemented.");
+  }
+
+  get status(): number {
+    return this.#state.response!.status;
+  }
+
+  get statusText(): string {
+    return this.#state.response!.statusText;
+  }
+
+  open(method: string, url: string): void {
+    this.#state.draft = {
+      method,
+      url: new URL(url),
+      headers: new Headers(),
+    };
+    this.#setReadyState(this.OPENED);
+  }
+
+  overrideMimeType(type: types.XMLHttpRequestResponseType): void {
+    this.#state.computed = {
+      ...this.#state.computed,
+      type,
+    } as State["computed"];
+  }
+
+  setRequestHeader(name: string, value: string): void {
+    // it should be opened before doing this
+    if (this.readyState === this.OPENED) {
+      this.#state.draft!.headers.set(name, value);
+    }
+  }
+
+  getResponseHeader(name: string) {
+    return this.#state.response!.headers.get(name);
+  }
+
+  getAllResponseHeaders(): string {
+    return Array.from(this.#state.response!.headers.entries())
+      .map(([k, v]) => `${k}: ${v}`)
+      .join("\r\n");
+  }
+
+  send(body?: BodyInit | null): void {
+    const controller = new AbortController();
+    const draft = this.#state.draft!;
+
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+      // deno-lint-ignore no-explicit-any
+      (this as any).ontimeout?.();
+    }, this.timeout);
+
+    fetch(draft.url, {
+      ...draft,
+      body,
+      signal: controller.signal,
+    })
+      .then((res) => {
+        clearTimeout(timeoutId);
+        this.#state.response = res;
+        this.#setReadyState(this.HEADERS_RECEIVED);
+        this.#setReadyState(this.LOADING);
+
+        // Can't use `Promise.all` with `res.blob()` + `res.arrayBuffer()`
+        // because you can only call one of them. After that, the body is
+        // dropped which results in an error.
+
+        res.blob().then((blob) => {
+          blob.arrayBuffer().then((buf) => {
+            this.#state.computed = {
+              ...this.#state.computed,
+              text: new TextDecoder().decode(buf),
+              buffer: buf,
+              blob,
+            } as State["computed"];
+            this.#state.computed!.type ??= "text";
+            this.#setReadyState(this.DONE);
+            // deno-lint-ignore no-explicit-any
+            (this as any).onload?.();
+          });
+        });
+      })
+      .catch((e) => {
+        clearTimeout(timeoutId);
+        // deno-lint-ignore no-explicit-any
+        (this as any).onerror?.(e);
+      });
+    this.#state.controller = controller;
+  }
+
+  // This will not work at the moment because fetch does not currently support
+  // the `AbortController` API in Deno.
+
+  abort(): void {
+    this.#state.controller!.abort();
+  }
+}

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,0 +1,11 @@
+import { XMLHttpRequest } from "./mod.ts";
+
+import { assertEquals } from "https://deno.land/std@0.97.0/testing/asserts.ts";
+
+Deno.test("Ready State Callbacks", () => {
+  const xhr = new XMLHttpRequest();
+  let times = 0;
+  xhr.onreadystatechange = () => void times++;
+  xhr.open("GET", "https://foo.bar");
+  assertEquals(times, 1);
+});

--- a/pollyfill.ts
+++ b/pollyfill.ts
@@ -1,0 +1,4 @@
+import { XMLHttpRequest } from "./mod.ts";
+
+// deno-lint-ignore no-explicit-any
+(window as any).XMLHttpRequest = XMLHttpRequest;


### PR DESCRIPTION
I saw this repo and sorta caught a coding bug.  3 hours later and here I am.  Sorry about the lack of tests, but I was using a development file and testing it out as I went and I also didn't know what to do about mocking requests.  Here is what I was using to play around with stuff:

```ts
import { XMLHttpRequest } from "./mod.ts";

const xhr = new XMLHttpRequest();

xhr.onreadystatechange = () => {
  console.log({ newState: xhr.readyState });
};

xhr.open("GET", "https://icanhazdadjoke.com");
xhr.overrideMimeType("json");

xhr.onload = () => {
  const data = xhr.response;

  console.log(data);
  console.log(xhr.readyState);
};

xhr.onerror = console.error;

xhr.setRequestHeader("accept", "application/json"); // the API requires this header to work

xhr.send();
```

I did not implement the `addEventListener`/`dispatchEvent`/`removeEventListener` functionality with `EventTarget` as I have no idea how to do it.  You can simply use the `on${event}` for testing, but it definitely needs to be added.  Also, I did not include the Upload API as I don't have enough time for it.  You, or someone else, can work on it if you want tho.

You can pull it in or not, I don't really care as it was fun to work on ;)

Edit: I forgot to note that the Abort API is actually not working with the Fetch API ATM but the `abort` function will work perfectly after it is implemented in Deno as I tested my code on Chrome.

Anotha one: I pulled the spec type definitions from the TypeScript repo as it should therefore allow people to write code that works in both Deno and Node.js (or whatever TypeScript env) as the types match.

Update for Deno v1.11
* Deno v1.11 now includes a working implementation of the Aborter API and how you can use it within the Fetch API so this now works with aborting requests.
* Deno v1.11 also upgraded to TypeScript 4.3 which allows for private methods and accessors so I have migrated the single private method to use that syntax.